### PR TITLE
BUG - A linha de separação do header está sobrepondo o menu no mobile #77

### DIFF
--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -36,6 +36,7 @@
   width: 100vw;
   height: 0.2rem;
   position: absolute;
+  z-index: -1;
   left: 0;
   top: 0;
   margin-top: 7.2rem;


### PR DESCRIPTION
# O que foi feito?

- [x] Foi corrigido o bug da linha de separação do `header` vazando para o menu aberto do `mobile`

###### Issue
#77 
